### PR TITLE
Use consistent type hints

### DIFF
--- a/src/Geometry.php
+++ b/src/Geometry.php
@@ -128,7 +128,7 @@ class Geometry
     /**
      * Pass the data to geoPHP to convert to the correct geometry type.
      *
-     * @param string $data
+     * @param string|object $data
      * @param string $type
      *
      * @return bool|\GeometryCollection|mixed


### PR DESCRIPTION
Calling the parse method directly with a Geometry object is breaking static code analysis tools like phpstan.