### PR TITLE
Add explicit object and string checks before calling method_exists() for PHP 8 compatibility.

### DIFF
--- a/src/Support/GeometryProxy.php
+++ b/src/Support/GeometryProxy.php
@@ -164,7 +164,7 @@ class GeometryProxy
      */
     protected function exposeRawIfAvailable($argument)
     {
-        return (method_exists($argument, 'getRawGeometry'))
+        return ((\is_string($argument) || \is_object($argument)) && method_exists($argument, 'getRawGeometry'))
             ? $argument->getRawGeometry()
             : $argument;
     }


### PR DESCRIPTION
After upgrading to PHP 8 I started getting errors with this method call. `method_exists` got stricter when checking the type of the first argument passed in. You can see more about the change here: https://bugs.php.net/bug.php?id=79623